### PR TITLE
Enhance the scheduler for the timeout cases. 

### DIFF
--- a/cpukit/rtems/include/rtems/rtems/ratemon.h
+++ b/cpukit/rtems/include/rtems/rtems/ratemon.h
@@ -229,6 +229,20 @@ typedef struct {
    * This field contains the statistics maintained for the period.
    */
   Rate_monotonic_Statistics               Statistics;
+
+  /** KHCHEN 01.08
+   * This field contains the number of postponed jobs. It is updated by
+   * the period watchdog, when the watchdog timeout, this variable will
+   * be increased immediately and the deadline of next period is renewed.
+   */
+  uint32_t                                postponed_jobs;
+
+  /** KHCHEN 02.08
+   *  This field contains the tick of the latest deadline decided by the period
+   *  watchdog. 
+   */
+  uint64_t                                latest_deadline;
+
 }   Rate_monotonic_Control;
 
 /**

--- a/cpukit/rtems/include/rtems/rtems/ratemonimpl.h
+++ b/cpukit/rtems/include/rtems/rtems/ratemonimpl.h
@@ -116,6 +116,28 @@ bool _Rate_monotonic_Get_status(
   Timestamp_Control            *cpu_since_last_period
 );
 
+/**
+ * Kuan-Hsun Chen, 03.08.2016
+ * This routine is prepared for the watchdog timeout to renew its deadline
+ * without releasing jobs. A postponed job induced by a deadline miss should be
+ * released by RMS manager.
+ */
+void _Rate_monotonic_Renew_deadline(
+  Rate_monotonic_Control *the_period,
+  Thread_Control         *owner,
+  ISR_lock_Context       *lock_context
+);
+
+/**
+ * Kuan-Hsun Chen, 04.08.2016
+ * This is a helper function to return the number of postponed jobs by this
+ * given period. This number is only increased by the corresponding watchdog,
+ * and is decreased by RMS manager with the postponed job releasing.
+ */
+uint32_t _Rate_monotonic_Postponed_num(
+  rtems_id                period_id
+);
+
 void _Rate_monotonic_Restart(
   Rate_monotonic_Control *the_period,
   Thread_Control         *owner,

--- a/cpukit/rtems/src/ratemonperiod.c
+++ b/cpukit/rtems/src/ratemonperiod.c
@@ -323,10 +323,14 @@ uint32_t _Rate_monotonic_Postponed_num(
   /* This is a helper function to return the number of postponed jobs in the given period. */
   Rate_monotonic_Control             *the_period;
   ISR_lock_Context                    lock_context;
+  Thread_Control                     *owner;
 
   the_period = _Rate_monotonic_Get( period_id, &lock_context );
   _Assert(the_period != NULL);
-  return the_period->postponed_jobs;
+  uint32_t jobs = the_period->postponed_instances;
+  owner = the_period->owner;
+  _Rate_monotonic_Release( owner, &lock_context );
+  return jobs;
 }
 
 rtems_status_code rtems_rate_monotonic_period(

--- a/cpukit/rtems/src/ratemontimeout.c
+++ b/cpukit/rtems/src/ratemontimeout.c
@@ -62,7 +62,20 @@ void _Rate_monotonic_Timeout( Watchdog_Control *the_watchdog )
       _Thread_Unblock( owner );
     }
   } else {
+#if 0
     the_period->state = RATE_MONOTONIC_EXPIRED;
     _Rate_monotonic_Release( owner, &lock_context );
+#else
+    /* KHCHEN 02.08 - revise according to Gedare suggestion
+     * If the watchdog is timeout, it means there is an additional postponed
+     * job in the next period which is not available to release job:
+     * Either the current task is still executed, or it is preemptive by the
+     * other higher priority tasks.
+     */
+
+    the_period->postponed_jobs += 1;
+    the_period->state = RATE_MONOTONIC_EXPIRED;
+    _Rate_monotonic_Renew_deadline( the_period, owner, &lock_context );
+#endif
   }
 }

--- a/testsuites/samples/Makefile.am
+++ b/testsuites/samples/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I ../aclocal
 
-_SUBDIRS = hello capture ticker base_sp unlimited minimum fileio
+_SUBDIRS = hello capture ticker base_sp unlimited minimum fileio deadlinemiss
 
 if MPTESTS
 ## base_mp is a sample multiprocessing test

--- a/testsuites/samples/configure.ac
+++ b/testsuites/samples/configure.ac
@@ -76,5 +76,6 @@ iostream/Makefile
 cdtest/Makefile
 pppd/Makefile
 capture/Makefile
+deadlinemiss/Makefile
 ])
 AC_OUTPUT

--- a/testsuites/samples/deadlinemiss/Makefile.am
+++ b/testsuites/samples/deadlinemiss/Makefile.am
@@ -1,0 +1,19 @@
+
+rtems_tests_PROGRAMS = deadlinemiss
+deadlinemiss_SOURCES = system.h \
+	init.c \
+	tasks.c	
+
+include $(RTEMS_ROOT)/make/custom/@RTEMS_BSP@.cfg
+include $(top_srcdir)/../automake/compile.am
+include $(top_srcdir)/../automake/leaf.am
+
+
+LINK_OBJS = $(deadlinemiss_OBJECTS)
+LINK_LIBS = $(deadlinemiss_LDLIBS) -lm
+
+deadlinemiss$(EXEEXT): $(deadlinemiss_OBJECTS) $(deadlinemiss_DEPENDENCIES)
+	@rm -f deadlinemiss$(EXEEXT)
+	$(make-exe)
+
+include $(top_srcdir)/../automake/local.am

--- a/testsuites/samples/deadlinemiss/init.c
+++ b/testsuites/samples/deadlinemiss/init.c
@@ -1,0 +1,68 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#define CEILING_POS(X) ((X-(int)(X)) > 0 ? (int)(X+1) : (int)(X))
+#define CONFIGURE_INIT
+#include "system.h"
+#include <rtems/test.h>
+#include <rtems/status-checks.h>
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int experiment_flag = 0;
+int testnumber = 15;
+rtems_id Task_id[ 2 ];
+rtems_name Task_name[ 2 ];
+uint32_t tick_per_second;
+
+rtems_task Init(
+	rtems_task_argument argument
+)
+{
+  rtems_status_code status;
+
+	tick_per_second = rtems_clock_get_ticks_per_second();
+	printf("\nTicks per second in your system: %" PRIu32 "\n", tick_per_second);
+
+  Task_name[ 1 ] = rtems_build_name( 'T', 'A', '1', ' ' );
+  Task_name[ 2 ] = rtems_build_name( 'T', 'A', '2', ' ' );
+
+
+  //Two tasks creating
+  status = rtems_task_create(
+    Task_name[ 1 ], 2, RTEMS_MINIMUM_STACK_SIZE * 2, RTEMS_DEFAULT_MODES,
+    RTEMS_DEFAULT_ATTRIBUTES, &Task_id[ 1 ]
+  );
+  if ( status != RTEMS_SUCCESSFUL) {
+    printf( "rtems_task_create 1 failed with status of %d.\n", status );
+    exit( 1 );
+  } 
+
+  status = rtems_task_create(
+    Task_name[ 2 ], 5, RTEMS_MINIMUM_STACK_SIZE * 2, RTEMS_DEFAULT_MODES,
+    RTEMS_DEFAULT_ATTRIBUTES, &Task_id[ 2 ]
+  );
+  if ( status != RTEMS_SUCCESSFUL) {
+    printf( "rtems_task_create 2 failed with status of %d.\n", status );
+    exit( 1 );
+  }
+
+  //After creating the periods for tasks, start to run them sequencially.
+
+  experiment_flag = 1;
+	status = rtems_task_start( Task_id[ 1 ], Task_1, 1);
+  if ( status != RTEMS_SUCCESSFUL) {
+    printf( "rtems_task_start 1 failed with status of %d.\n", status );
+    exit( 1 );
+  }
+  status = rtems_task_start( Task_id[ 2 ], Task_2, 1);
+  if ( status != RTEMS_SUCCESSFUL) {
+    printf( "rtems_task_start 2 failed with status of %d.\n", status );
+    exit( 1 );
+  }
+
+	status = rtems_task_delete( RTEMS_SELF );
+}

--- a/testsuites/samples/deadlinemiss/system.h
+++ b/testsuites/samples/deadlinemiss/system.h
@@ -1,0 +1,142 @@
+/*
+ *
+ *  COPYRIGHT (c) 1989-2007.
+ *  On-Line Applications Research Corporation (OAR).
+ *
+ *  The license and distribution terms for this file may be
+ *  found in the file LICENSE in this distribution or at
+ *  http://www.rtems.com/license/LICENSE.
+ */
+/*  updated for SEMAPHORE test, 15/02/2016, Kuan-Hsun Chen */
+
+
+#include <inttypes.h>
+#include <rtems.h>
+
+/* functions */
+
+rtems_task Init(
+  rtems_task_argument argument
+);
+
+rtems_task Task_1(
+  rtems_task_argument argument
+);
+
+rtems_task Task_2(
+  rtems_task_argument argument
+);
+
+
+
+/* global variables */
+
+/*
+ *  Keep the names and IDs in global variables so another task can use them.
+ */ 
+
+extern rtems_id   Task_id[ 2 ];         /* array of task ids */
+extern rtems_name Task_name[ 2 ];       /* array of task names */
+extern uint32_t tick_per_second;
+extern int ntask;
+extern int testnumber;
+extern int experiment_flag;
+
+/* configuration information */
+
+#include <bsp.h> /* for device driver prototypes */
+
+#define CONFIGURE_APPLICATION_NEEDS_CONSOLE_DRIVER
+#define CONFIGURE_APPLICATION_NEEDS_CLOCK_DRIVER
+#define CONFIGURE_MICROSECONDS_PER_TICK     1000   // NB: 10 and lower gives system failure for erc32 simulator
+#define CONFIGURE_MAXIMUM_TASKS             11
+#define CONFIGURE_MAXIMUM_SEMAPHORES        1
+#define CONFIGURE_MAXIMUM_PRIORITY          15
+#define CONFIGURE_EXTRA_TASK_STACKS         (20 * RTEMS_MINIMUM_STACK_SIZE)
+
+// Needed for RM Mangager
+#define CONFIGURE_MAXIMUM_PERIODS           11
+
+#define CONFIGURE_RTEMS_INIT_TASKS_TABLE
+
+/* Needed for erc32 simulator.. */
+/* ..for using "CPU_usage_Dump", since it uses printf("%f") if your processor has floating points) */
+/* If you want to take away FP support (to avoid heavy context switch), you must rewrite CPU_usage_Dump instead */
+//#define CONFIGURE_INIT_TASK_ATTRIBUTES RTEMS_FLOATING_POINT
+//#define CONFIGURE_INIT_TASK_INITIAL_MODES RTEMS_PREEMPT
+
+
+#include <rtems/confdefs.h>
+
+/*
+ *  Handy macros and static inline functions
+ */
+
+/*
+ *  Macro to hide the ugliness of printing the time.
+ */
+
+#define print_time(_s1, _tb, _s2) \
+  do { \
+    printf( "%s%02" PRIu32 ":%02" PRIu32 ":%02" PRIu32 \
+       "   %02" PRIu32 "/%02" PRIu32 "/%04" PRIu32 "%s", \
+       _s1, (_tb)->hour, (_tb)->minute, (_tb)->second, \
+       (_tb)->month, (_tb)->day, (_tb)->year, _s2 ); \
+    fflush(stdout); \
+  } while ( 0 )
+
+/*
+ *  Macro to print an task name that is composed of ASCII characters.
+ *
+ */
+
+#define put_name( _name, _crlf ) \
+  do { \
+    uint32_t c0, c1, c2, c3; \
+    \
+    c0 = ((_name) >> 24) & 0xff; \
+    c1 = ((_name) >> 16) & 0xff; \
+    c2 = ((_name) >> 8) & 0xff; \
+    c3 = (_name) & 0xff; \
+    putchar( (char)c0 ); \
+    if ( c1 ) putchar( (char)c1 ); \
+    if ( c2 ) putchar( (char)c2 ); \
+    if ( c3 ) putchar( (char)c3 ); \
+    if ( (_crlf) ) \
+      putchar( '\n' ); \
+  } while (0)
+
+/*
+ *  Macro to loop.
+ */
+
+
+#define LOOP(_et, taskID){ \
+  \
+  int start = 0; \
+  int now = 0; \
+  start = rtems_clock_get_ticks_since_boot();\
+  while(1){\
+	\
+    now = rtems_clock_get_ticks_since_boot();\
+	  if(now-start >= _et){\
+	  	break;\
+    }\
+ }\
+}
+
+/*
+ *  This allows us to view the "Test_task" instantiations as a set
+ *  of numbered tasks by eliminating the number of application
+ *  tasks created.
+ *
+ *  In reality, this is too complex for the purposes of this
+ *  example.  It would have been easier to pass a task argument. :)
+ *  But it shows how rtems_id's can sometimes be used.
+ */
+
+#define task_number( tid ) \
+  ( rtems_get_index( tid ) - \
+     rtems_configuration_get_rtems_api_configuration()->number_of_initialization_tasks )
+
+/* end of include file */

--- a/testsuites/samples/deadlinemiss/tasks.c
+++ b/testsuites/samples/deadlinemiss/tasks.c
@@ -1,0 +1,150 @@
+/**
+ *  COPYRIGHT (c) 1989-2007.
+ *  On-Line Applications Research Corporation (OAR).
+ *
+ *  The license and distribution terms for this file may be
+ *  found in the file LICENSE in this distribution or at
+ *  http://www.rtems.com/license/LICENSE.
+ */
+/*  updated for triple test, 2003/11/06, Erik Adli */
+
+#include "system.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* CPU usage and Rate monotonic manger statistics */
+#include "rtems/cpuuse.h"
+//
+// Periods for the various tasks [seconds]
+#define PERIOD_TASK_1          10000
+#define PERIOD_TASK_2          2000
+
+
+// Task Id
+#define ID_TASK_1           0
+#define ID_TASK_2          	1
+
+// Execution time for each task
+#define task_1_normal_et	6000
+#define task_2_normal_et	1000
+
+// TASK 1
+rtems_task Task_1(
+  rtems_task_argument unused
+)
+{
+  rtems_status_code status;
+  rtems_name        period_name; 
+  rtems_id          RM_period;
+  rtems_id selfid=rtems_task_self();
+  double            start, end; //sttime, entime;
+  int		    tsk_counter = 0;
+  int		    startTick = 0;
+
+  /*create period*/
+
+  period_name = rtems_build_name( 'P', 'E', 'R', '1' );
+  status = rtems_rate_monotonic_create( period_name, &RM_period );
+  if( RTEMS_SUCCESSFUL != status ) {
+    printf("RM failed with status: %d\n", status);
+    exit(1);
+  }
+
+	while( 1 ) {
+    /*this part for release offset*/
+		status = rtems_rate_monotonic_period( RM_period,PERIOD_TASK_1);
+
+		if(tsk_counter == 2){
+			
+				status = rtems_rate_monotonic_delete(RM_period);
+				if(status != RTEMS_SUCCESSFUL){
+					printf("BUG: Cannot delete the period 1\n");
+					exit(1);
+				}
+                  
+				status=rtems_task_delete(selfid);
+				if(status != RTEMS_SUCCESSFUL){
+					printf("BUG: Cannot delete the task 1\n");
+					exit(1);
+				}
+
+		}else{
+					
+			startTick = rtems_clock_get_ticks_since_boot();
+			start = startTick  / (double)tick_per_second;
+
+	    printf("Task 1 starts current second %.6f.\n", start);
+
+			LOOP(task_1_normal_et,task_id);
+		
+			end = rtems_clock_get_ticks_since_boot()/(double)tick_per_second;
+
+			printf("					Task 1 ends at current second  %.6f .\n", end);
+ 			tsk_counter += 1;			
+		}
+	}
+}
+
+// TASK 2
+rtems_task Task_2(
+  rtems_task_argument unused
+)
+{
+  rtems_id selfid=rtems_task_self();
+  rtems_status_code status;
+  rtems_name        period_name; 
+  rtems_id          RM_period;
+  double 	          start, end;
+  int		            tsk_counter = 0;
+  int		            startTick = 0;
+
+  /*create period*/
+
+  period_name = rtems_build_name( 'P', 'E', 'R', '2' );
+  status = rtems_rate_monotonic_create( period_name, &RM_period );
+  if( RTEMS_SUCCESSFUL != status ) {
+    printf("RM failed with status: %d\n", status);
+    exit(1);
+  }
+
+	while( 1 ) {
+ 
+		/*this part for release offset*/
+		status = rtems_rate_monotonic_period( RM_period, PERIOD_TASK_2);
+
+		if(experiment_flag ==0){
+			status = rtems_rate_monotonic_delete(RM_period);
+			if(status != RTEMS_SUCCESSFUL){
+				printf("BUG: Cannot delete the period 2\n");
+				exit(1);
+			}
+      exit(1); //before delete itself, otherwise this task is dead.
+			status=rtems_task_delete(selfid);
+			if(status != RTEMS_SUCCESSFUL){
+				printf("BUG: Cannot delete the task 2\n");
+				exit(1);
+			}		
+		}else{
+
+			startTick = rtems_clock_get_ticks_since_boot();
+			start = startTick  / (double)tick_per_second;
+
+			printf("Task 2 starts at current second %.6f.\n", start);
+
+			LOOP(task_2_normal_et,task_id);
+
+			end = rtems_clock_get_ticks_since_boot()/(double)tick_per_second;
+
+			printf("					%d Task 2 ends at current second %.6f.\n", tsk_counter+1, end);
+	    
+			tsk_counter += 1;
+			    
+      if(tsk_counter == testnumber){        
+        rtems_rate_monotonic_report_statistics();
+        experiment_flag=0;
+      }
+		}
+	}
+}
+


### PR DESCRIPTION
In current implementation, if a task period is time out, the next call of rtems_rate_monotonic_period() will only release one following job and manipulate the task period with the calling moment + the next length of period. However, it is in fact changing the behaviour of a periodic task.

There maybe more than one postponed instances due to the preemption and the task period was unpredictable and shifted due to the deadline misses. I believe this patch is good for further use in more general real-time task models. To demonstrate the differences, a heuristic example called deadlinemiss is prepared in testsuites/samples/ to show the benefit of the enhancement.

Given two tasks with implicit deadline that task deadline is equal to its period. 
Task 1 period is 10000 ticks, whereas task 2 is 2000 ticks.
Task 1 has the execution time 6000 ticks, and task 2 has 1000 ticks.
Assume Task 1 has a higher priority than task 2. Task 1 only executes 2 times.
In the expected result, we can observe that the postponed jobs are continuously released till there is no postponed job left, and the task period will still keep as it is.

- Three additional functions: 
RM_Postponed_num, RM_Renew_deadline, and RM_Release_postponed_job. 
- Four refined functions: 
RM_Activate, RM_Block_while_expired, rtems_rate_monotonic_period, RM_Timeout. 
- Rate_monotonic_Control structure: 
It contains one counter for the number of postponed jobs and one variable for the recent_deadline.