### PR TITLE
cpukit/dev/serial: Including "sys/ioctl"

### DIFF
--- a/cpukit/dev/serial/sc16is752.c
+++ b/cpukit/dev/serial/sc16is752.c
@@ -14,7 +14,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <fcntl.h>
-
+#include <sys/ioctl.h>
 #include <rtems/seterr.h>
 
 #include "sc16is752-regs.h"


### PR DESCRIPTION
The original "sc16is752.c" code lacks the definition of some constants, such as "TIOCM_CTS" (Line 325), "TIOCM_DSR" (Line 328), "TIOCM_RI" (Line 331), ....

By including "sys/ioctl" the definitions will be fixed.