### PR TITLE
fix: update support for raspberry pi uart

### DIFF
--- a/bsps/arm/raspberrypi/console/console-config.c
+++ b/bsps/arm/raspberrypi/console/console-config.c
@@ -186,7 +186,7 @@ static void uart_probe(void)
 
   fdt = bsp_fdt_get();
 
-  node = fdt_node_offset_by_compatible(fdt, -1, "brcm,bcm2835-pl011");
+  node = fdt_node_offset_by_compatible(fdt, -1, "arm,pl011");
   init_ctx_arm_pl011(fdt, node);
 
   node = fdt_node_offset_by_compatible(fdt, -1, "brcm,bcm2835-aux-uart");


### PR DESCRIPTION
4 years ago, the official raspberry pi device trees have been changed to use a different compatible value for their uart0 peripheral. [Device Tree Reference](https://github.com/raspberrypi/linux/blame/rpi-6.1.y/arch/arm/boot/dts/bcm283x.dtsi#L305)

Maybe some test suites still use the old raspberry pi device tree. Since I don't know the project by heart, can someone guide me towards all the changes I still have to do to have this PR be accepted? Or just accept it if no change has to be made :)